### PR TITLE
Update OCP - patterns

### DIFF
--- a/pages/ocp/patterns.mdx
+++ b/pages/ocp/patterns.mdx
@@ -84,7 +84,7 @@ class AppConfigurator {
 Этот шаблон позволяет менять настройки, конфигурацию или алгоритм в зависимости от ситуации и требований. В нашем случае стратегии мы отдадим выбор необходимой фабрики:
 
 ```ts
-function formatterStrategy(reportType: ReportTypes): FormatterFactory {
+function formatterStrategy(reportType: ReportTypes) {
   const formatters = {
     [ReportTypes.Html]: HtmlFormatterFactory,
     [ReportTypes.Txt]: TxtFormatterFactory,


### PR DESCRIPTION
We can not use FormatterFactory as function signature, because we return class itself, not instance. That cause a ts compiler error.