### PR TITLE
Replace "authentificate" with "authenticate"

### DIFF
--- a/components/Quiz/quizzes/dip-ideal-3/variant-1.mdx
+++ b/components/Quiz/quizzes/dip-ideal-3/variant-1.mdx
@@ -8,6 +8,6 @@ class MongoDbConnection {
 class Auth {
   connection: MongoDbConnection
   constructor(connection: MongoDbConnection) {/*...*/}
-  authentificate(login: string, password: string) {/*...*/}
+  authenticate(login: string, password: string) {/*...*/}
 }
 ```

--- a/components/Quiz/quizzes/dip-ideal-3/variant-2.mdx
+++ b/components/Quiz/quizzes/dip-ideal-3/variant-2.mdx
@@ -12,6 +12,6 @@ class MongoDbConnection implements DataBaseConnection {
 class Auth {
   connection: MongoDbConnection
   constructor(connection: MongoDbConnection) {/*...*/}
-  authentificate(login: string, password: string) {/*...*/}
+  authenticate(login: string, password: string) {/*...*/}
 }
 ```

--- a/components/Quiz/quizzes/dip-ideal-3/variant-3.mdx
+++ b/components/Quiz/quizzes/dip-ideal-3/variant-3.mdx
@@ -12,6 +12,6 @@ class MongoDbConnection implements DataBaseConnection {
 class Auth {
   connection: DataBaseConnection
   constructor(connection: DataBaseConnection) {/*...*/}
-  authentificate(login: string, password: string) {/*...*/}
+  authenticate(login: string, password: string) {/*...*/}
 }
 ```

--- a/pages/dip/in-ideal-world.mdx
+++ b/pages/dip/in-ideal-world.mdx
@@ -26,7 +26,7 @@ class Auth {
     this.connection = connection
   }
 
-  async authentificate(login: string, password: string): Promise<AuthResult> {/*...*/}
+  async authenticate(login: string, password: string): Promise<AuthResult> {/*...*/}
 }
 ```
 
@@ -56,7 +56,7 @@ class Auth {
     this.connection = connection
   }
 
-  authentificate(login: string, password: string) {/*...*/}
+  authenticate(login: string, password: string) {/*...*/}
 }
 ```
 

--- a/pages/dip/in-real-life.mdx
+++ b/pages/dip/in-real-life.mdx
@@ -27,8 +27,8 @@ describe('Auth', () => {
     auth = new Auth(connection)
   })
 
-  it('should successfully authentificate user', async () => {
-    const result: AuthResult = await auth.authentificate('Alex', '123')
+  it('should successfully authenticate user', async () => {
+    const result: AuthResult = await auth.authenticate('Alex', '123')
     expect(result.status).toEqual(200)
   })
 })


### PR DESCRIPTION
There's no such word as "authenti*fi*cate" in English, the right word is "authenticate". This PR replaces all the occurrences of the former word with the latter one.