### PR TITLE
Change IoC wording in Russian

### DIFF
--- a/pages/dip/in-real-life.mdx
+++ b/pages/dip/in-real-life.mdx
@@ -9,7 +9,7 @@ export default ({ children }) => <MainLayout meta={meta}>{children}</MainLayout>
 
 # В реальной жизни
 
-Для большего контроля над зависимостями и упрощения тестирования DIP предлагает использовать [инверсию контроля](https://en.wikipedia.org/wiki/Inversion_of_control) (Inversion of Control, IoC) и [инъекцию зависимостей](https://en.wikipedia.org/wiki/Dependency_injection) (Dependency Injection, DI).
+Для большего контроля над зависимостями и упрощения тестирования DIP предлагает использовать [инверсию управления](https://en.wikipedia.org/wiki/Inversion_of_control) (Inversion of Control, IoC) и [инъекцию зависимостей](https://en.wikipedia.org/wiki/Dependency_injection) (Dependency Injection, DI).
 
 ## DIP, DI и тестирование
 
@@ -66,9 +66,9 @@ describe('Auth', () => {
 
 Класс `DbMock` реализует интерфейс `DataBaseConnection`. Мы можем спроектировать его максимально простым и лёгким, это ускорит работу теста.
 
-## Инверсия контроля
+## Инверсия управления
 
-DI — это частный случай [инверсии контроля](https://en.wikipedia.org/wiki/Inversion_of_control). При этом подходе контроль за выполнением программы отдаётся фреймворку, который знает, в какой момент и какую функцию надо вызвать. Цель IoC — сделать систему расширяемой.
+DI — это частный случай [инверсии управления](https://en.wikipedia.org/wiki/Inversion_of_control). При этом подходе контроль за выполнением программы отдаётся фреймворку, который знает, в какой момент и какую функцию надо вызвать. Цель IoC — сделать систему расширяемой.
 
 [Inversify](http://inversify.io/) предлагает решение для IoC на TypeScript. Inversify предоставляет API для создания контейнеров с указанием зависимостей, которые потом подставляются автоматически.
 


### PR DESCRIPTION
Based on the [IoC article in Russian](https://ru.wikipedia.org/wiki/%D0%98%D0%BD%D0%B2%D0%B5%D1%80%D1%81%D0%B8%D1%8F_%D1%83%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D1%8F), the term's translation should be "инверсия управления". I've changed related occurrences accordingly, hope this makes sense.